### PR TITLE
Make npm bundle smaller

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.25.2",
   "description": "Library of associative containers; it implements TreeMap, TreeSet, TreeMultiMap and TreeMultiSet classes",
   "main": "jstreemap.js",
+  "files": [
+    "/jstreemap.js"
+  ],
   "scripts": {
     "analyze-tests": "node ./tools/analyze-tests.js dev-tests.xml",
     "esdoc": "esdoc -c ./esdoc.json",


### PR DESCRIPTION
The `npm` bundle comes with everything and tests. But also comes with the docs, which is >90% of the package total size:

![image](https://user-images.githubusercontent.com/4335188/54135428-0e398580-441a-11e9-9874-b3c2e881705b.png)

I'm adding the `files` entry in `package.json` to tell `npm` to only publish that file. Please let me know if some other file should be packed.